### PR TITLE
Make syntax consistent with ES6. Change port to 8080.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 lame.js
 node_modules
 sendgrid.env
+
+.idea/
+package-lock.json

--- a/server.js
+++ b/server.js
@@ -1,9 +1,9 @@
-var express = require('express');
-var bodyParser = require('body-parser');
-var butter = require('./butter-cms.controller');
-var request = require('request');
-var PORT = process.env.PORT || 80;
-var app = express();
+const express = require('express');
+const bodyParser = require('body-parser');
+const butter = require('./butter-cms.controller');
+const request = require('request');
+const PORT = process.env.PORT || 8080;
+const app = express();
 
 app.use(express.static('public'));
 
@@ -11,10 +11,12 @@ app.get('/cmsdata', butter.getContent);
 
 require('./sendGrid')(app);
 
-app.listen(PORT, (err) =>{
-  if (err){
-    console.log('Server error:', err);
-  } else {
+app.listen(PORT, () => {
     console.log(`Server up and running on port: ${PORT}`);
-  }
+}).on('error', (err) => {
+    if(err.errno === 'EADDRINUSE') {
+        console.log(`port ${PORT} busy`);
+    } else {
+        console.log('Server error:', err);
+    }
 });


### PR DESCRIPTION
Using port 80 is not recommended as any port below 1024 requires node to
run as root. Server.js had a mix of ES5 and ES6 so made it consistent
with ES6. Added error handler to `listen` call. Add .idea and package-lock.json to gitignore.
