### PR TITLE
remove old function call when clicking on Learn More tab.

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -64,8 +64,8 @@
             <div ng-if="main.menuActive" ng-mouseleave="main.menuActive = !main.menuActive" sytle="position: absolute;">
                 <a href="#/" class="small-nav-link"><div>Home</div></a>
                 <a href="#/about" class="small-nav-link"><div>About</div></a>
-                <a href="#/getHelp" class="small-nav-link" ng-click="main.getHelpData()"><div>Get Help</div></a>
-                <a href="#/dv" class="small-nav-link" ng-click="main.dvData()"><div>Learn More</div></a>
+                <a href="#/getHelp" class="small-nav-link"><div>Get Help</div></a>
+                <a href="#/dv" class="small-nav-link"><div>Learn More</div></a>
                 <a href="#/giveHelp" class="small-nav-link"><div>Get Involved</div></a>
                 <a href="#/resources" class="small-nav-link"><div>Resources</div></a>
             </div>

--- a/public/js/controller.main.js
+++ b/public/js/controller.main.js
@@ -88,14 +88,7 @@ function mainController($http, $location, $sce) {
 
             /////////////////////// RESOURCES PAGE DATA //////////////////////////////
 
-
             main.resources = main.awp.resources;
-
-
-
-            if ($location.$$absUrl.slice(17) === '#/getHelp'){
-                main.getHelpData();
-            }
 
             // Save events info into array
             main.events = main.awp.events;


### PR DESCRIPTION
This function call was "used" to place the text on the page. Its purpose has been refactored (see #54) and it is no longer needed.